### PR TITLE
Add Welch FFT tab in TestSignalView

### DIFF
--- a/myBrain/View/SpectrumView.swift
+++ b/myBrain/View/SpectrumView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct SpectrumView: View {
+    let psd: [Double]
+
+    var body: some View {
+        GeometryReader { geo in
+            Canvas { context, size in
+                guard psd.count > 1 else { return }
+                let maxVal = psd.max() ?? 1
+                let stepX = size.width / CGFloat(psd.count - 1)
+                var path = Path()
+                for i in 0..<psd.count {
+                    let x = stepX * CGFloat(i)
+                    let normalized = CGFloat(psd[i] / maxVal)
+                    let y = size.height - normalized * size.height
+                    if i == 0 { path.move(to: CGPoint(x: x, y: y)) }
+                    else { path.addLine(to: CGPoint(x: x, y: y)) }
+                }
+                context.stroke(path, with: .color(.purple), lineWidth: 2)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- compute Welch power spectrum in `SignalProcessing`
- draw basic FFT with new `SpectrumView`
- add TabView in `TestSignalView` to switch between waveform and FFT

## Testing
- `swiftc -parse View/TestSignalView.swift View/SignalProcessing.swift View/SpectrumView.swift`

------
https://chatgpt.com/codex/tasks/task_e_687322e259748329bc26a91cc99b438d