### PR TITLE
Add live FFT timer

### DIFF
--- a/myBrain/View/SpectrumView.swift
+++ b/myBrain/View/SpectrumView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct SpectrumView: View {
+    let psd: [Double]
+    var yLimit: Double = 100.0
+
+    var body: some View {
+        GeometryReader { geo in
+            Canvas { context, size in
+                guard psd.count > 1 else { return }
+                let maxVal = yLimit
+                let stepX = size.width / CGFloat(psd.count - 1)
+                var path = Path()
+                for i in 0..<psd.count {
+                    let x = stepX * CGFloat(i)
+                    let clamped = min(psd[i], maxVal)
+                    let normalized = CGFloat(clamped / maxVal)
+                    let y = size.height - normalized * size.height
+                    if i == 0 { path.move(to: CGPoint(x: x, y: y)) }
+                    else { path.addLine(to: CGPoint(x: x, y: y)) }
+                }
+                context.stroke(path, with: .color(.purple), lineWidth: 2)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- compute FFT from the latest 256 samples
- schedule timer during recording to update FFT plot automatically
- display placeholder text while FFT data is loading
- clamp FFT plot with y-limit and refresh timer on main loop

## Testing
- `swiftc -parse myBrain/View/TestSignalView.swift myBrain/View/SignalProcessing.swift myBrain/View/SpectrumView.swift`


------
https://chatgpt.com/codex/tasks/task_e_687322e259748329bc26a91cc99b438d