### PR TITLE
Add real-time TBR plot

### DIFF
--- a/myBrain/View/SignalProcessing.swift
+++ b/myBrain/View/SignalProcessing.swift
@@ -373,3 +373,22 @@ extension SignalProcessing {
         return Array(accumulated[0...maxIndex])
     }
 }
+
+extension SignalProcessing {
+    static func thetaBetaRatio(psd: [Double], sampleRate: Double) -> Double {
+        guard !psd.isEmpty else { return 0.0 }
+        let windowSize = 256.0
+        let binWidth = sampleRate / windowSize
+        func power(in range: ClosedRange<Double>) -> Double {
+            let start = Int(range.lowerBound / binWidth)
+            let end = Int(range.upperBound / binWidth)
+            let clampedStart = max(0, start)
+            let clampedEnd = min(psd.count - 1, end)
+            guard clampedEnd >= clampedStart else { return 0.0 }
+            return psd[clampedStart...clampedEnd].reduce(0, +)
+        }
+        let thetaPower = power(in: 4.0...8.0)
+        let betaPower = power(in: 13.0...30.0)
+        return betaPower != 0 ? thetaPower / betaPower : 0.0
+    }
+}

--- a/myBrain/View/SignalProcessing.swift
+++ b/myBrain/View/SignalProcessing.swift
@@ -391,4 +391,24 @@ extension SignalProcessing {
         let betaPower = power(in: 13.0...30.0)
         return betaPower != 0 ? thetaPower / betaPower : 0.0
     }
+
+    /// Compute a simple moving average with the provided window size.
+    /// - Parameters:
+    ///   - values: Array of values to smooth.
+    ///   - windowSize: Number of points to average over.
+    /// - Returns: The smoothed array.
+    static func movingAverage(values: [Double], windowSize: Int) -> [Double] {
+        guard windowSize > 1, !values.isEmpty else { return values }
+        var result: [Double] = []
+        var sum: Double = 0
+        for (index, value) in values.enumerated() {
+            sum += value
+            if index >= windowSize {
+                sum -= values[index - windowSize]
+            }
+            let count = min(windowSize, index + 1)
+            result.append(sum / Double(count))
+        }
+        return result
+    }
 }

--- a/myBrain/View/TBRPlotView.swift
+++ b/myBrain/View/TBRPlotView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct TBRPlotView: View {
+    let values: [Double]
+    let color: Color
+
+    var body: some View {
+        GeometryReader { geo in
+            Canvas { context, size in
+                guard values.count > 1 else { return }
+
+                let minVal = values.min() ?? 0
+                let maxVal = values.max() ?? 1
+                let range = max(maxVal - minVal, 0.0001)
+                let stepX = size.width / CGFloat(values.count - 1)
+
+                var path = Path()
+                for i in 0..<values.count {
+                    let x = CGFloat(i) * stepX
+                    let normalized = (values[i] - minVal) / range
+                    let y = size.height - CGFloat(normalized) * size.height
+                    if i == 0 {
+                        path.move(to: CGPoint(x: x, y: y))
+                    } else {
+                        path.addLine(to: CGPoint(x: x, y: y))
+                    }
+                }
+                context.stroke(path, with: .color(color), lineWidth: 2)
+            }
+        }
+    }
+}

--- a/myBrain/View/TBRPlotView.swift
+++ b/myBrain/View/TBRPlotView.swift
@@ -4,20 +4,23 @@ struct TBRPlotView: View {
     let values: [Double]
     let color: Color
 
+    private let smoothWindow = 5
+
     var body: some View {
         GeometryReader { geo in
             Canvas { context, size in
-                guard values.count > 1 else { return }
+                let smoothed = SignalProcessing.movingAverage(values: values, windowSize: smoothWindow)
+                guard smoothed.count > 1 else { return }
 
-                let minVal = values.min() ?? 0
-                let maxVal = values.max() ?? 1
+                let minVal = smoothed.min() ?? 0
+                let maxVal = smoothed.max() ?? 1
                 let range = max(maxVal - minVal, 0.0001)
-                let stepX = size.width / CGFloat(values.count - 1)
+                let stepX = size.width / CGFloat(smoothed.count - 1)
 
                 var path = Path()
-                for i in 0..<values.count {
+                for i in 0..<smoothed.count {
                     let x = CGFloat(i) * stepX
-                    let normalized = (values[i] - minVal) / range
+                    let normalized = (smoothed[i] - minVal) / range
                     let y = size.height - CGFloat(normalized) * size.height
                     if i == 0 {
                         path.move(to: CGPoint(x: x, y: y))


### PR DESCRIPTION
## Summary
- compute theta/beta ratio using new `thetaBetaRatio` helper
- track TBR for each channel when computing FFT
- add `TBRPlotView` for displaying a line plot
- show new TBR tab in TestSignalView

## Testing
- `swiftc -parse View/TBRPlotView.swift View/SignalProcessing.swift View/TestSignalView.swift`

------
https://chatgpt.com/codex/tasks/task_e_6874480cb06c8329a17c280c7d83781c